### PR TITLE
Holo.Light --> DeviceDefault

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -17,7 +17,8 @@
 <resources>
 
     <style name="Theme.CreateShortCut" parent="android:Theme.Holo.DialogWhenLarge" />
-    <style name="Settings" parent="android:Theme.Holo.Light">
+    
+    <style name="Settings" parent="android:Theme.DeviceDefault">
         <item name="drawer_background">@drawable/drawer_background</item>
         <item name="drawer_shadow">@drawable/drawer_shadow</item>
         <item name="ic_drawer">@drawable/ic_drawer</item>


### PR DESCRIPTION
I remember running the ROM a while ago, and there was one case where the text was white-on-white, making it difficult to read.

I know you can't change a ListViews textColor unless you switch the whole theme of the app, so I'm thinking this may be a good fix. Holo Light looks elegant, dont get me wrong, but it almost seems 'out of place' in the Settings app because the background of this ROMs settings is the stock color. So, using DeviceDefault might work better.
